### PR TITLE
Remove unused policy_names from Example_DNA_v1

### DIFF
--- a/libs/Example_DNA_v1.py
+++ b/libs/Example_DNA_v1.py
@@ -147,7 +147,6 @@ def generate_ideas(df_with_features: pd.DataFrame, meta: Dict[str, Any]) -> pd.D
     vol = df.get("vol_20")
     if vol is None:
         vol = df["close"].pct_change().rolling(20, min_periods=20).std()
-    policy_names = [p["name"] for p in EXIT_POLICIES]
     policy_idx = np.zeros(len(df), dtype=int)
     high_vol = vol > vol.rolling(200, min_periods=50).median()
     # 0 -> fixed_rr_1_2, 1 -> atr_2x


### PR DESCRIPTION
## Summary
- remove unused `policy_names` variable from `generate_ideas`
- confirm `policy_idx` logic relies solely on volatility

## Testing
- `python -m py_compile libs/Example_DNA_v1.py`
- `python - <<'PY'
from libs.Example_DNA_v1 import calculate_features, generate_ideas
import pandas as pd
import numpy as np
n=250
rng=pd.date_range('2021-01-01', periods=n, freq='1H')
price=100+np.cumsum(np.random.randn(n))
high=price+np.random.rand(n)
low=price-np.random.rand(n)
open_=price+np.random.randn(n)*0.1
close=price+np.random.randn(n)*0.1
volume=np.random.randint(1,1000,n)
df=pd.DataFrame({'open_time':rng,'open':open_,'high':high,'low':low,'close':close,'volume':volume})
feats=calculate_features(df,{})
ideas=generate_ideas(feats,{})
print(ideas[['entry_action','policy_choice']].head())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6898ef6466fc832ea5e11d9761935101