### PR TITLE
Organize standard imports in backtester app

### DIFF
--- a/apps/backtester_app.py
+++ b/apps/backtester_app.py
@@ -1,9 +1,9 @@
 # apps/backtester_app.py
 from __future__ import annotations
 
+from pathlib import Path
 import json
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import joblib


### PR DESCRIPTION
## Summary
- Ensure `backtester_app` explicitly imports `Path`, `json`, and `datetime` at the top of the module.

## Testing
- `python -m py_compile apps/backtester_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ff780c5c832e88041618a2c1268c