### PR TITLE
Clean imports and record training timings

### DIFF
--- a/apps/trainer_app.py
+++ b/apps/trainer_app.py
@@ -1,7 +1,6 @@
 # apps/trainer_app.py
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Dict, List
 


### PR DESCRIPTION
## Summary
- remove unused io, json, and TimeSeriesSplit imports
- track execution time for feature generation, label building, and model fitting
- drop unused json import from trainer app

## Testing
- `flake8 libs/training.py apps/trainer_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689902312d20832e8e08d846da7662c8